### PR TITLE
Change homepage button colors to match those used in report and suggestion forms

### DIFF
--- a/static/css/Menu.css
+++ b/static/css/Menu.css
@@ -13,7 +13,7 @@
 	display: block;
 	width: 250px;
 	padding: 20px;
-	background-color: #4CAF50;
+	background-color: #0056b3;
 	color: white;
 	text-decoration: none;
 	border-radius: 8px;
@@ -35,7 +35,7 @@
 
 .menu-button:hover {
 	transform: scale(1.05);
-	background-color: #45a049;
+	background-color: #003d80;
 }
 
 .menu-content h2 {
@@ -51,12 +51,12 @@
 }
 
 .menu-button.disabled {
-	background-color: #8eb590;
+	background-color: #6096D0;
 	transition: none;
 	cursor: default;
 }
 
 .menu-button.disabled:hover {
 	transform: scale(1.0);
-	background-color: #8eb590;
+	background-color: #6096D0;
 }


### PR DESCRIPTION
## Title: Fixes #5 

## Description
I went ahead and changed the button colors on the homepage to match those that are used in the report forms, the buttons to the report form, and the buttons for suggestion forms. This is so these colors are consistent and better for accessibility.

## Checklist
- [x] Updated buttons colors at static/css/Menu.css