### PR TITLE
Added yaml entries for RITLUG and FOSSRIT

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -112,3 +112,14 @@
       description: 'Getting things done at RIT'
       link: '#'
       disabled: "(Coming soon)"
+- section_title: Clubs and Organizations
+  links:
+    - icon: "book"
+      title: 'FOSSRIT Wiki Page'
+      description: 'FOSSRIT Wiki Page'
+      disabled: "(Coming soon)"
+      link: '#'  
+    - icon: "book"
+      title: 'LUG Wiki'
+      description: 'RIT Linux Users Group Wiki Page'
+      link: https://wiki.ritlug.com/

--- a/data/links.yaml
+++ b/data/links.yaml
@@ -112,14 +112,16 @@
       description: 'Getting things done at RIT'
       link: '#'
       disabled: "(Coming soon)"
-- section_title: Clubs and Organizations
-  links:
+#Uncomment and add the FOSSRIT wiki page if it ever gets created
+
+#- section_title: Clubs and Organizations
+#  links:
+#    - icon: "book"
+#      title: 'Free and Open Source Software RIT Wiki'
+#      description: 'FOSSRIT Wiki Page'
+#      disabled: "(Coming soon)"
+#      link: '#'  
     - icon: "book"
-      title: 'FOSSRIT Wiki Page'
-      description: 'FOSSRIT Wiki Page'
-      disabled: "(Coming soon)"
-      link: '#'  
-    - icon: "book"
-      title: 'LUG Wiki'
-      description: 'RIT Linux Users Group Wiki Page'
+      title: 'RIT Linux Users Wiki'
+      description: 'RITLUG Wiki Page'
       link: https://wiki.ritlug.com/


### PR DESCRIPTION
Solves #1 
I added two new links for RITLUG and FOSS RIT. FOSSRIT still doesn't seem to have an official wiki, so I made that one a work in progress. I added the section "Clubs and Organizations" since other categories were full and it didn't seem to fit them anyway. Let me know if this is to your liking.